### PR TITLE
Update edge image locations in deviceconfig.json

### DIFF
--- a/TypeEdge.Host/deviceconfig.json
+++ b/TypeEdge.Host/deviceconfig.json
@@ -14,7 +14,7 @@
           "edgeAgent": {
             "type": "docker",
             "settings": {
-              "image": "microsoft/azureiotedge-agent:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
               "createOptions": ""
             }
           },
@@ -23,9 +23,8 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "microsoft/azureiotedge-hub:1.0",
-              "createOptions": "{\n  \"HostConfig\": {\n    \"PortBindings\": {\n      \"8883/tcp\": [\n        {\n          \"HostPort\": \"8883\"\n        }\n      ],\n      \"443/tcp\": [\n        {\n          \"HostPort\": \"443\"\n        }\n      ]\n    }\n  }\n}"
-            }
+              "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+              "createOptions": "{\n  \"HostConfig\": {\n    \"PortBindings\": {\n      \"8883/tcp\": [\n        {\n          \"HostPort\": \"8883\"\n        }\n      ],\n      \"443/tcp\": [\n        {\n          \"HostPort\": \"443\"\n        }\n      ],\n      \"5671/tcp\": [\n        {\n          \"HostPort\": \"5671\"\n        }\n      ]\n    }\n  }\n}"            }
           }
         },
         "modules": {


### PR DESCRIPTION
At GA, the images are under mcr.microsoft.com/ rather than microsoft/. Additionally, the 5671 port mapping is now a default mapping for edge hub.