### PR TITLE
Add possibility to override transport settings

### DIFF
--- a/Microsoft.Azure.TypeEdge.Host/TypeEdgeHost.cs
+++ b/Microsoft.Azure.TypeEdge.Host/TypeEdgeHost.cs
@@ -530,12 +530,12 @@ namespace Microsoft.Azure.TypeEdge.Host
 
        public void RegisterTransportSettings(ITransportSettings transportSettings)
        {
-           _containerBuilder.RegisterInstance(instance);
+           _containerBuilder.RegisterInstance(transportSettings);
        }
 
        public void RegisterTransportSettingsForHost(ITransportSettings transportSettings)
        {
-           _containerBuilder.RegisterInstance(instance).Named<ITransportSettings>(nameof(TypeEdgeHost) + "TransportSettings");
+           _containerBuilder.RegisterInstance(transportSettings).Named<ITransportSettings>(nameof(TypeEdgeHost) + "TransportSettings");
        }
 
        public void RegisterTransportSettingsForModule<T>(ITransportSettings transportSettings)
@@ -546,7 +546,7 @@ namespace Microsoft.Azure.TypeEdge.Host
        public void RegisterTransportSettingsForModule(ITransportSettings transportSettings, Type moduleType)
        {
            var moduleName = moduleType.GetProxyInterface().GetModuleName();
-           _containerBuilder.RegisterInstance(instance).Named<ITransportSettings>(moduleName + "TransportSettings");
+           _containerBuilder.RegisterInstance(transportSettings).Named<ITransportSettings>(moduleName + "TransportSettings");
        }
 
         #endregion

--- a/Microsoft.Azure.TypeEdge/Modules/TypeModule.cs
+++ b/Microsoft.Azure.TypeEdge/Modules/TypeModule.cs
@@ -137,7 +137,12 @@ namespace Microsoft.Azure.TypeEdge.Modules
             if (string.IsNullOrEmpty(_connectionString))
                 Logger.LogWarning($"Missing {Constants.EdgeHubConnectionStringKey} variable.");
 
-            var settings = new AmqpTransportSettings(TransportType.Amqp_Tcp_Only);
+
+            var settings =  
+                container.ResolveOptionalNamed<ITransportSettings>(Name + "TransportSettings")
+                ?? container.ResolveOptional<ITransportSettings>()
+                ?? new AmqpTransportSettings(TransportType.Amqp_Tcp_Only);
+           
             var disableSslCertificateValidationKey =
                 configuration.GetValue($"{Constants.DisableSslCertificateValidationKey}", false);
 
@@ -299,7 +304,7 @@ namespace Microsoft.Azure.TypeEdge.Modules
                     throw new ArgumentException(
                         $"{GetType().Name} has needs to implement an single interface annotated with the TypeModule Attribute");
 
-                return proxyInterface.Name.Substring(1).ToLower(CultureInfo.CurrentCulture);
+                return proxyInterface.GetModuleName();
             }
         }
 

--- a/Microsoft.Azure.TypeEdge/Modules/TypeModule.cs
+++ b/Microsoft.Azure.TypeEdge/Modules/TypeModule.cs
@@ -138,18 +138,13 @@ namespace Microsoft.Azure.TypeEdge.Modules
                 Logger.LogWarning($"Missing {Constants.EdgeHubConnectionStringKey} variable.");
 
 
-            var settings =  
+            var settings =
                 container.ResolveOptionalNamed<ITransportSettings>(Name + "TransportSettings")
                 ?? container.ResolveOptional<ITransportSettings>()
-                ?? new AmqpTransportSettings(TransportType.Amqp_Tcp_Only);
-           
-            var disableSslCertificateValidationKey =
-                configuration.GetValue($"{Constants.DisableSslCertificateValidationKey}", false);
+                ?? DefaultTransport(configuration);
 
-            if (disableSslCertificateValidationKey)
-                settings.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) =>
-                    true;
-            _transportSettings = new ITransportSettings[] {settings};
+
+            _transportSettings = new ITransportSettings[] { settings };
 
             return Init();
         }
@@ -371,6 +366,20 @@ namespace Microsoft.Azure.TypeEdge.Modules
         #endregion
 
         #region private methods
+
+        private static ITransportSettings DefaultTransport(IConfigurationRoot configuration)
+        {
+            var settings = new AmqpTransportSettings(TransportType.Amqp_Tcp_Only);
+
+            var disableSslCertificateValidationKey = configuration.GetValue($"{Constants.DisableSslCertificateValidationKey}", false);
+
+            if (disableSslCertificateValidationKey)
+            {
+                settings.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) =>  true;
+            }
+
+            return settings;
+        }
 
         private Task<MethodResponse> MethodCallback(MethodRequest methodRequest, object userContext)
         {

--- a/Microsoft.Azure.TypeEdge/Startup.cs
+++ b/Microsoft.Azure.TypeEdge/Startup.cs
@@ -24,7 +24,11 @@ namespace Microsoft.Azure.TypeEdge
     {
         public static TypeModule Module { get; set; }
 
-        public static async Task DockerEntryPoint(string[] args)
+        public static async Task DockerEntryPoint(string[] args) : this(args, null)
+        {
+        }
+
+        public static async Task DockerEntryPoint(string[] args, Action<ContainerBuilder> registerServices)
         {
             var cancellationTokenSource = new CancellationTokenSource();
             AssemblyLoadContext.Default.Unloading += ctx => cancellationTokenSource.Cancel();
@@ -33,6 +37,12 @@ namespace Microsoft.Azure.TypeEdge
             var services = new ServiceCollection().AddLogging();
             var containerBuilder = new ContainerBuilder();
             containerBuilder.Populate(services);
+
+            if(registerServices != null)
+            {
+                registerServices(containerBuilder);
+            }
+            
             containerBuilder.RegisterBuildCallback(c => { });
 
             var configuration = new ConfigurationBuilder()

--- a/Microsoft.Azure.TypeEdge/Startup.cs
+++ b/Microsoft.Azure.TypeEdge/Startup.cs
@@ -24,8 +24,9 @@ namespace Microsoft.Azure.TypeEdge
     {
         public static TypeModule Module { get; set; }
 
-        public static async Task DockerEntryPoint(string[] args) : this(args, null)
+        public static Task DockerEntryPoint(string[] args)
         {
+            return DockerEntryPoint(args, null);
         }
 
         public static async Task DockerEntryPoint(string[] args, Action<ContainerBuilder> registerServices)


### PR DESCRIPTION
The current implementation was using hard coded Amqp transport for all scenarios, both for local debugging using the TypeEdgeHost, as well as when running modules on actual edge devices using Docker and the Edge Runtime.

This might not be desired for all scenarios - either because MQTT is more appropriate, or because on some local development machines / networks only Http transport will work.

This PR lets users choose which transport they want and override transports either globally or per module.

Since I'm not sure how you have implemented versioning / publishing of nugets, I have NOT updated version numbers in project files or nuspecs.